### PR TITLE
added changes needed for running script on OSX

### DIFF
--- a/Pesquisa de Orcamentos Familiares/download all microdata.R
+++ b/Pesquisa de Orcamentos Familiares/download all microdata.R
@@ -1,6 +1,6 @@
 #if running on a macintosh, uncomment the lines below
-options( encoding="windows-1252" )
-Sys.setlocale(,"pt_BR")
+options( encoding="LATIN-9" )
+
 # analyze survey data for free (http://asdfree.com) with the r language
 # pesquisa orcamentos familiares
 # 2002-2003 and 2008-2009
@@ -370,7 +370,7 @@ for ( year in years.to.download ){
       data.file <- gsub( ".7Z" , ".7z" , basename(toupper(data.file) ) )
       data.file <- paste(td,"Dados",data.file,sep="/")
       # build the string to send to DOS
-            dos.command <- paste0( '"' , path.to.7z , '" x ' , data.file, "-aoa" )
+            dos.command <- paste0( '"' , path.to.7z , '" x ' , data.file, " -aoa" )
       
       # extract the file
       system( dos.command )


### PR DESCRIPTION
This is the modified script for downloading all data files into macintosh. The following changes were needed:
1- Set encoding to LATIN-9
2- OSX uses a different 7-zip application
3- OSX needs you to specify a path to perl when using read.xls
4- OSX needs you to specify a path to unzip application
5- I had to add some folders to the paths leading to the extracted files
6- OS is case sensitive: cur file stem needs and extension need to be in the right case 
