### PR TITLE
update to National Longitudinal Surveys/download all microdata.R - allow restart

### DIFF
--- a/National Longitudinal Surveys/download all microdata.R
+++ b/National Longitudinal Surveys/download all microdata.R
@@ -192,6 +192,15 @@ for ( this.study in study.names ){
 		# remove any negative ones, since those are not rnums themselves
 		all.option.values <- all.option.values[ all.option.values != "-1" ]
 
+                ## get list of already download files (in case you've had to start and then stop)
+                already.stored <- lapply(list.files(this.dir), FUN = function(x) strsplit(x, split = '\\.')[[1]][1])
+
+                ## unlist
+                already.stored <- unlist(already.stored)
+
+                ## subset so we only download what hasn't already been downloaded
+                all.option.values <- all.option.values[!(all.option.values %in% already.stored)]
+
 		# loop through each available rnum extract
 		for ( option.value in all.option.values ){
 


### PR DESCRIPTION
Since NLSY downloads take so long, I added code to check the working directory for already downloaded files and then subset the full list of files to be downloaded to exclude those that were found. This allows for a restart from where you left off.